### PR TITLE
Update Golang builder image to use brew.registry.redhat.io

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,12 +1,9 @@
 # Build arguments
 ARG SOURCE_CODE=.
 
-FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.22.2@sha256:9576ac41e16b2262d2871a4064394d650d73221ceb07d1877772fbe98c6f0b6f AS golang
-
-
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22.2@sha256:9576ac41e16b2262d2871a4064394d650d73221ceb07d1877772fbe98c6f0b6f AS golang
 
 FROM registry.redhat.io/ubi8/ubi@sha256:8990388831e1b41c9a67389e4b691dae8b1283f77d5fb7263e1f4fc69c0a9d05 AS builder
-
 
 ARG GOLANG_VERSION=1.22.2
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-15522 