### PR TITLE
Pin openshift-golang-builder to 1.23 rhel8 tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,7 @@
         "schedule": ["at any time"],
         "branchPrefix": "renovate/rpm/",
        "semanticCommits": "enabled"
-      }    
+      }
     ],
     "dockerfile": {
       "enabled": true,
@@ -117,7 +117,7 @@
       ]
     },
     "rpm": {
-    "enabled": true,   
+    "enabled": true,
     "schedule": ["at any time"]
   },
     "prHourlyLimit": 0

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -2,7 +2,7 @@
 ARG SOURCE_CODE=.
 
 # BEGIN -- workaround lack of go-toolset for golang 1.23
-ARG GOLANG_IMAGE=registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@sha256:b848cf648a383b6e207ebd150afc7e65a90efe0d7734f4f6d2767144d58d68d0
+ARG GOLANG_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23@sha256:ca0c771ecd4f606986253f747e2773fe2960a6b5e8e7a52f6a4797b173ac7f56
 FROM ${GOLANG_IMAGE} AS golang
 
 FROM registry.access.redhat.com/ubi8/ubi@sha256:fd93fc09dc09f3d3edae30577460a979bb52df351b826ef3a5c02ec8213b433a AS builder

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -2,8 +2,7 @@
 ARG SOURCE_CODE=.
 
 # BEGIN -- workaround lack of go-toolset for golang 1.23
-ARG GOLANG_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23@sha256:ca0c771ecd4f606986253f747e2773fe2960a6b5e8e7a52f6a4797b173ac7f56
-FROM ${GOLANG_IMAGE} AS golang
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_golang_1.23@sha256:ca0c771ecd4f606986253f747e2773fe2960a6b5e8e7a52f6a4797b173ac7f56 AS golang
 
 FROM registry.access.redhat.com/ubi8/ubi@sha256:fd93fc09dc09f3d3edae30577460a979bb52df351b826ef3a5c02ec8213b433a AS builder
 ARG GOLANG_VERSION=1.23.0


### PR DESCRIPTION
In 4f3ee0f (#177), 1.23 was introduced, but just referenced by manifest digest. Unfortunately the Konflux bot appears to have assumed that it was the `latest` tag, and saw a "new" (read: several years old) digest for that tag, and bumped to it in 3798127 (#178) .

This change specifies the rhel_8_golang_1.23 tag, so that it will only bump to newer versions of _that_ tag.

This change also changes the registry domain to be brew.registry.redhat.io, since 68487ea (#194) appears to indicate that that's preferred/required for Konflux. One can use the `--build-arg` CLI option to use the registry-proxy locally as needed.