### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-codeflare-operator-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -32,7 +32,8 @@ ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="odh-codeflare-operator-container" \
       description="Manages lifecycle of MCAD and InstaScale custom resources and associated Kubernetes resources" \
-      name="managed-open-data-hub/odh-codeflare-operator-container-rhel8" \
+      name="rhoai/odh-codeflare-operator-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       summary="odh-codeflare-operator-container" \
       maintainer="['managed-open-data-hub@redhat.com']" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
