### PR TITLE
fix(RHOAIENG-68496): reduce secrets RBAC to minimum required verbs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -119,11 +119,8 @@ rules:
   - secrets
   verbs:
   - create
-  - delete
   - get
-  - list
   - patch
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 	awctrl "github.com/project-codeflare/appwrapper/pkg/controller"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"go.uber.org/zap/zapcore"
-	"golang.org/x/exp/slices"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -440,9 +439,12 @@ func isAPIAvailable(ctx context.Context, mgr ctrl.Manager, apiName string) bool 
 	crdList, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{})
 	exitOnError(err, "unable to list CRDs")
 
-	return slices.ContainsFunc(crdList.Items, func(crd apiextensionsv1.CustomResourceDefinition) bool {
-		return crd.Name == apiName
-	})
+	for i := range crdList.Items {
+		if crdList.Items[i].Name == apiName {
+			return true
+		}
+	}
+	return false
 }
 
 func waitForAPI(ctx context.Context, mgr ctrl.Manager, apiName string, action func()) {
@@ -453,9 +455,14 @@ func waitForAPI(ctx context.Context, mgr ctrl.Manager, apiName string, action fu
 	exitOnError(err, "unable to list CRDs")
 
 	// If API is already available, just invoke action
-	if slices.ContainsFunc(crdList.Items, func(crd apiextensionsv1.CustomResourceDefinition) bool {
-		return crd.Name == apiName
-	}) {
+	apiFound := false
+	for i := range crdList.Items {
+		if crdList.Items[i].Name == apiName {
+			apiFound = true
+			break
+		}
+	}
+	if apiFound {
 		action()
 		return
 	}
@@ -483,13 +490,20 @@ func waitForAPI(ctx context.Context, mgr ctrl.Manager, apiName string, action fu
 				exitOnError(apierrors.FromObject(event.Object), fmt.Sprintf("error watching for API %v", apiName))
 
 			case watch.Added, watch.Modified:
-				if crd := event.Object.(*apiextensionsv1.CustomResourceDefinition); crd.Name == apiName &&
-					slices.ContainsFunc(crd.Status.Conditions, func(condition apiextensionsv1.CustomResourceDefinitionCondition) bool {
-						return condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue
-					}) {
-					setupLog.Info(fmt.Sprintf("API %v installed, invoking deferred action", apiName))
-					action()
-					return
+				crd := event.Object.(*apiextensionsv1.CustomResourceDefinition)
+				if crd.Name == apiName {
+					established := false
+					for i := range crd.Status.Conditions {
+						if crd.Status.Conditions[i].Type == apiextensionsv1.Established && crd.Status.Conditions[i].Status == apiextensionsv1.ConditionTrue {
+							established = true
+							break
+						}
+					}
+					if established {
+						setupLog.Info(fmt.Sprintf("API %v installed, invoking deferred action", apiName))
+						action()
+						return
+					}
 				}
 			}
 		}

--- a/pkg/controllers/raycluster_controller.go
+++ b/pkg/controllers/raycluster_controller.go
@@ -95,7 +95,7 @@ var (
 // +kubebuilder:rbac:groups=ray.io,resources=rayclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes;routes/custom-host,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;create;update;patch;delete;watch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;patch;delete;get;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;create;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;create;update;patch;delete;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;create;update;patch;delete;watch
@@ -680,7 +680,6 @@ func (r *RayClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rayv1.RayCluster{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Secret{}).
 		Owns(&networkingv1.Ingress{}).
 		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(&rbacv1.ClusterRoleBinding{}, handler.EnqueueRequestsFromMapFunc(


### PR DESCRIPTION
## Description

Backport of the RBAC fix to rhoai-2.25.

Remove `delete`, `list`, and `watch` from the raycluster controller's secrets RBAC marker
and remove the `.Owns(&corev1.Secret{})` watch registration.

The controller only uses `Get` and `Apply` (create+patch) on secrets via a direct typed client —
it never deletes secrets or relies on informer-driven reconciliation from secret changes.

The cert-controller's separate marker (`get/list/watch/update`) remains unchanged as those verbs
are required by its namespaced cache and Update-based cert rotation.

**Net effect on the generated ClusterRole:** the second secrets rule block drops from
`[create, delete, get, list, patch, watch]` to `[create, get, patch]`.

Jira: [RHOAIENG-68496](https://redhat.atlassian.net/browse/RHOAIENG-68496)

## How Has This Been Tested?

- `make test-unit` passes with the reduced RBAC verbs
- Verified `controller-gen` output matches the updated role.yaml

## Merge criteria

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [ ] The developer has manually tested the changes and verified that the changes work.